### PR TITLE
Return custom error if a participant already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cd insights-agent-api
 The application currently uses Django's out-of-the-box testing environment. You can run all tests using the manage.py comment.
   
   ```Shell
-  docker compose up python manage.py test
+  docker compose run web python manage.py test
   ```
 
 ### 7. Setting breakpoints for debugging

--- a/api/tests/views/test_auth_view.py
+++ b/api/tests/views/test_auth_view.py
@@ -61,10 +61,9 @@ class AuthenticationAPITest(TestCase):
             content_type="application/json"
         )
         response_data = response.json()
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response_data['message'], 'invalid credentials')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_data["error"], 'It looks like you have already signed up for this study with this phone number. Please follow the instructions given via text message. If you have not received a text message, please email tech4all@buildJUSTLY.org')
         self.assertEqual(StudyParticipant.objects.count(), 1)
-        mock_send_sms.assert_not_called
 
     def test_confirm_magic_link_post_request_success(self):
         otp_client = OtpClient()

--- a/api/utils.py
+++ b/api/utils.py
@@ -27,8 +27,6 @@ def is_phone_number_taken(phone_number):
 
 
 def create_study_participant(full_name, phone_number):
-    if StudyParticipant.objects.filter(phone_number=phone_number).exists():
-        return None
 
     User = get_user_model()
     user = User.objects.create(username=str(uuid.uuid4()))


### PR DESCRIPTION
Fixes #24 
[Companion Web PR](https://github.com/specollective/insights-agent-web-app/pull/81)
If a user is already a participant and tries to signup the send_magic_link endpoint would return a 400 error. 
Instead, send the user a new link and allow them to continue.
This may need a more robust sign up/login flow checking if the participant has already been confirmed and/or already filled out a survey but for now keeps users from hitting a dead end.