### PR TITLE
Fix table key naming issue

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -115,17 +115,21 @@ class DataEntryAdmin(admin.ModelAdmin):
       "timestamp",
       "idle_time",
     )
+
     list_display = (
       "identifier",
       "application_name",
       "tab_name",
       "url",
       "internet_connection",
-      "timestamp",
+      "time",
     )
 
     def identifier(self, obj):
         return obj.token[-10:]
+
+    def time(self, obj):
+        return obj.timestamp.strftime("%Y-%m-%d %H:%M:%S")
 
 
 class UserAdmin(BaseUserAdmin):

--- a/api/models.py
+++ b/api/models.py
@@ -1,13 +1,13 @@
 import random
 import string
-from phonenumber_field.modelfields import PhoneNumberField
 from uuid import uuid4
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from phonenumber_field.modelfields import PhoneNumberField
 
-
+# We need to use the get_user_model to get the custom user model.
 User = get_user_model()
 
 
@@ -95,9 +95,9 @@ class DataEntry(models.Model):
 
 @receiver(post_save, sender=Survey)
 def set_uniq_table_key(sender, instance, created, **kwargs):
-    # The table key must be updated to be an unique alphanumeric key to be used as a postgres table name in the data injestion service.
+    # The table key must be updated to be an unique alphanumeric key to be used as a postgres table name in the data injestion service
     if created:
-        instance.table_key = f"_{instance.id}_{''.join(random.choices(string.ascii_uppercase + string.digits, k=16))}"
+        instance.table_key = f"_{instance.id}_{''.join(random.choices(string.ascii_uppercase + string.digits, k=16))}".lower()
         instance.save()
 
 @receiver(post_save, sender=User)

--- a/api/tests/models/test_survey.py
+++ b/api/tests/models/test_survey.py
@@ -1,0 +1,19 @@
+from api.models import Survey
+from django.test import TestCase
+
+
+class SurveyModelTest(TestCase):
+    """
+    Test module for Survey model
+    """
+
+    def test_survey_attributes(self):
+        survey = Survey.objects.create(
+            name="Demo",
+            slug="demo",
+        )
+
+        self.assertEqual(survey.name, 'Demo')
+        self.assertEqual(survey.slug, 'demo')
+        self.assertEqual(len(survey.table_key), 19)
+        self.assertTrue(survey.table_key.islower())

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,8 +1,12 @@
 import os
+import random
+import string
 import uuid
-from cryptography.fernet import Fernet
-from django.contrib.auth import get_user_model
+
 from rest_framework_simplejwt.tokens import RefreshToken
+from cryptography.fernet import Fernet
+
+from django.contrib.auth import get_user_model
 from api.models import StudyParticipant
 from api.services import OtpClient
 

--- a/api/views.py
+++ b/api/views.py
@@ -33,9 +33,8 @@ from api.utils import (
     create_study_participant,
     create_survey_token,
     find_study_participant_by_token,
-    get_tokens_for_user,
-    is_phone_number_taken,
 )
+
 from rest_framework_bulk import (
   BulkListSerializer,
   BulkModelViewSet,


### PR DESCRIPTION
Ran into an issue with creating new surveys. Postgresql downcases table names by default, so there was a mismatch between the ingestion table name and the Survey#table_key field. I updated the logic to force the string to be lowercase.